### PR TITLE
Mirage → Discovery

### DIFF
--- a/mirage/settings.py
+++ b/mirage/settings.py
@@ -182,14 +182,14 @@ SWAGGER_SETTINGS = {
     "is_superuser": False,  # Set to True to enforce admin only access
     "permission_denied_handler": None, # If user has no permisssion, raise 403 error
     "info": {
-        "contact": "mirage-18f@gsa.gov",
-        "title": "Mirage Market Research API",
+        "contact": "discovery-18f@gsa.gov",
+        "title": "Discovery Market Research API",
         "description": markdown.markdown("""
-This API drives the [Mirage Market Research Tool](https://mirage.gsa.gov).
+This API drives the [Discovery Market Research Tool](https://discovery.gsa.gov).
 It contains information on the vendors that are part of the OASIS and OASIS Small Business contracting vehicles, such as their contracting history, their elligibility for contract awards, and their small business designations.
-To learn more about the tool, please visit [Mirage](https://mirage.gsa.gov) or see the README on our [GitHub repository](https://github.com/18F/mirage).
+To learn more about the tool, please visit [Discovery](https://discovery.gsa.gov) or see the README on our [GitHub repository](https://github.com/18F/mirage).
 
-**Please note that the base path for this API is `https://api.data.gov/gsa/mirage/`**
+**Please note that the base path for this API is `https://api.data.gov/gsa/discovery/`**
 
 It requires an API key, obtainable at [api.data.gov](http://api.data.gov/).
 It must be passed in the `api_key` parameter with each request.

--- a/mirage_site/static/mirage_site/js/layout-manager-listings.js
+++ b/mirage_site/static/mirage_site/js/layout-manager-listings.js
@@ -30,7 +30,7 @@ LayoutManager.render = function(results) {
         }
     }
     //update document title
-    $(document).prop('title', "Results - Mirage");
+    $(document).prop('title', "Results - " + URLManager.title);
 
 };
 

--- a/mirage_site/static/mirage_site/js/layout-manager-vendor.js
+++ b/mirage_site/static/mirage_site/js/layout-manager-vendor.js
@@ -18,7 +18,7 @@ LayoutManager.init = function() {
 
 LayoutManager.render = function(results) {
     //update document title
-    $(document).prop('title', results.name + " - Mirage");
+    $(document).prop('title', results.name + " - " + URLManager.title);
 
     URLManager.updateVendorCSVURL(results);
 

--- a/mirage_site/static/mirage_site/js/url-manager.js
+++ b/mirage_site/static/mirage_site/js/url-manager.js
@@ -3,6 +3,8 @@
 'use strict';
 
 var URLManager = {
+    title: 'Discovery',
+
     init: function() {
         var naics = this.getParameterByName('naics-code');
         var setasides = this.getParameterByName('setasides');
@@ -72,7 +74,7 @@ var URLManager = {
     },
 
     update: function(results) {
-        History.pushState('', 'Mirage', this.getURL(results));
+        History.pushState('', this.title, this.getURL(results));
     },
 
     loadPoolPage: function(results) {

--- a/mirage_site/templates/api_theme/index.html
+++ b/mirage_site/templates/api_theme/index.html
@@ -2,7 +2,7 @@
 {% load staticfiles %}
 
 {% block title %}
-API Documentation / Mirage Market Research
+API Documentation - Discovery Market Research
 {% endblock %}
 
 {% block css %}

--- a/mirage_site/templates/index.html
+++ b/mirage_site/templates/index.html
@@ -39,7 +39,7 @@
                 <h4 class="inline data_source_name">FPDS</h4>
                 <span id="data_source_date_fpds"></span>
                 <span id="data_source_last_updated">last updated</span>
-                <span class="data_source_description"><br>Mirage loads data from the Federal Procurement Data System (FPDS) to automatically provide you with a context-rich contract history for each OASIS vendor, including the amount of the contract, the primary NAICS code and the pricing type.</span>
+                <span class="data_source_description"><br>Discovery loads data from the Federal Procurement Data System (FPDS) to automatically provide you with a context-rich contract history for each OASIS vendor, including the amount of the contract, the primary NAICS code and the pricing type.</span>
             </div><!-- end data_sources_row -->
         </div><!-- end data_sources -->
     <!-- END LANDING HTML -->    

--- a/selenium_tests/tests.py
+++ b/selenium_tests/tests.py
@@ -42,8 +42,8 @@ class FunctionalTests(LiveServerTestCase):
         driver = self.driver
         #open landing page
         driver.get(self.base_url + '/')
-        #make sure title of landing page is Mirage
-        self.assertEqual('Mirage', driver.title)
+        #make sure title of landing page is Discovery
+        self.assertEqual('Discovery', driver.title)
         #make sure subtitle of page is OASIS Market Research
         self.assertEqual('OASIS Market Research', driver.find_element_by_css_selector("span.oasis_subtitle").text)
 


### PR DESCRIPTION
Replace all of the externally facing mentions of "mirage" with "discovery". Some notes:

* I added `URLManager.title = "Discovery"` and changed the other managers that modify the document title to use this, so that if the site title needs to change again we only have to change it one place to get the titles fixed throughout.
* The URL `https://api.data.gov/gsa/discovery/` in our swagger settings 404s, but so did the mirage variant.
* I updated the Selenium title test but haven't been able to run them yet, so... :shrug: