### PR TITLE
Fix duplicate API endpoints in docs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ PyYAML==3.11
 boto==2.34.0
 coverage==3.7.1
 django-hstore==1.2.3
--e git+https://github.com/marcgibbons/django-rest-swagger.git#egg=django-rest-swagger
+-e git://github.com/18F/django-rest-swagger.git@fix-url-grouping#egg=django-rest-swagger
 djangorestframework==2.3.14
 psycopg2==2.5.3
 pytz==2014.4


### PR DESCRIPTION
This fix points our [django-rest-swagger] requirement at [a new 18F fork] with a cherry-picked [commit], which resolves the duplicate endpoints issue.

I wasn't sure whether the `#egg=django-rest-swagger` bit at the end of the URL was right, but it seems to work. You'll need to do this to test:

```sh
pip uninstall django-rest-swagger
pip install -r requirements.txt
```

[django-rest-swagger]: https://github.com/marcgibbons/django-rest-swagger
[a new 18F fork]: https://github.com/18F/django-rest-swagger/tree/fix-url-grouping
[commit]: https://github.com/18F/django-rest-swagger/commit/cd573e236df80e8a8a23b7c016806d386a029e07